### PR TITLE
Apply minor optimizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="La Padellina - Trattoria italienne authentique à Paris 15e. Cuisine traditionnelle, pizzas au feu de bois, pâtes fraîches maison. Réservation en ligne." />
     <meta name="keywords" content="restaurant italien, paris 15e, pizza, pasta, trattoria, cuisine italienne, réservation" />
+    <meta property="og:title" content="La Padellina - Trattoria Italienne Authentique à Paris 15e" />
+    <meta property="og:description" content="La Padellina, cuisine italienne traditionnelle, pizzas au feu de bois et pâtes fraîches maison." />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg" />
     <title>La Padellina - Trattoria Italienne Authentique à Paris 15e</title>
     <style>
       .text-shadow { text-shadow: 2px 2px 4px rgba(0,0,0,0.5); }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -65,6 +65,7 @@ const About = () => {
               <img
                 src="https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                 alt="Intérieur du restaurant"
+                loading="lazy"
                 className="w-full h-80 object-cover rounded-2xl shadow-lg"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent rounded-2xl"></div>
@@ -73,11 +74,13 @@ const About = () => {
               <img
                 src="https://images.pexels.com/photos/1438672/pexels-photo-1438672.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                 alt="Préparation des desserts"
+                loading="lazy"
                 className="w-full h-40 object-cover rounded-xl shadow-md"
               />
               <img
                 src="https://images.pexels.com/photos/1279330/pexels-photo-1279330.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                 alt="Pâtes fraîches"
+                loading="lazy"
                 className="w-full h-40 object-cover rounded-xl shadow-md"
               />
             </div>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -52,6 +52,7 @@ const Menu = () => {
                 <img
                   src={category.image}
                   alt={category.category}
+                  loading="lazy"
                   className="w-full h-full object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent"></div>

--- a/src/components/Reservation.tsx
+++ b/src/components/Reservation.tsx
@@ -17,7 +17,6 @@ const Reservation = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // In a real application, you would send this data to your backend
-    console.log('Reservation data:', formData);
     setIsSubmitted(true);
     setTimeout(() => setIsSubmitted(false), 3000);
   };
@@ -235,6 +234,7 @@ const Reservation = () => {
                 <img
                   src="https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                   alt="Intérieur chaleureux du restaurant"
+                  loading="lazy"
                   className="w-full h-64 object-cover"
                 />
               </div>


### PR DESCRIPTION
## Summary
- add Open Graph meta tags for richer previews
- lazy load images to speed up initial load
- remove a leftover console.log

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686684a781e48331b74d641768c5de0e